### PR TITLE
Fix NoMethodError in version detection section

### DIFF
--- a/drupalgeddon2.rb
+++ b/drupalgeddon2.rb
@@ -180,7 +180,7 @@ url.each do|uri|
 
     # If not, try and get it from the URL (In theory, these will never trigger/work as they will be HTTP 403)
     $drupalverion = uri.match(/includes\/database.inc/)? "6.x" : nil if $drupalverion.empty?
-    $drupalverion = uri.match(/core/)? "8.x" : "7.x" if $drupalverion.empty?
+    $drupalverion = uri.match(/core/)? "8.x" : "7.x" if $drupalverion.nil?
 
     # Done!
     break
@@ -189,7 +189,7 @@ url.each do|uri|
 
     # Get version from URL
     $drupalverion = uri.match(/includes\/database.inc/)? "6.x" : nil
-    $drupalverion = uri.match(/core/)? "8.x" : "7.x" if $drupalverion.empty?
+    $drupalverion = uri.match(/core/)? "8.x" : "7.x" if $drupalverion.nil?
   else
     puts "[!] MISSING: #{uri} (#{response.code})"
   end


### PR DESCRIPTION
Fixes `undefined method 'empty?' for nil:NilClass (NoMethodError)` in version detection, introduced in commit 16e166a9fde21a8d94c9c0158915ce571793deb8.