### PR TITLE
Opens up regex to include http in version check

### DIFF
--- a/drupalgeddon2.rb
+++ b/drupalgeddon2.rb
@@ -295,7 +295,7 @@ url.each do|uri|
 
   # Check header
   if response['X-Generator'] and $drupalverion.empty?
-    header = response['X-Generator'].slice(/Drupal (.*) \(https:\/\/www.drupal.org\)/, 1).to_s.strip
+    header = response['X-Generator'].slice(/Drupal (.*) \(https?:\/\/(www.)?drupal.org\)/, 1).to_s.strip
 
     if not header.empty?
       $drupalverion = "#{header}.x" if $drupalverion.empty?


### PR DESCRIPTION
Line 298 adds a ? (making s optional) to the s character of https to allow for http://www.drupal.org regex.
Also adds ? to (www.) also making that optional.